### PR TITLE
Redesign admin chiffres-clés dashboard with KPIs and new charts

### DIFF
--- a/sections/helpers/admin/admin_chiffre_cle.py
+++ b/sections/helpers/admin/admin_chiffre_cle.py
@@ -2,210 +2,165 @@ import pandas as pd
 import polars as pl
 import altair as alt
 import streamlit as st
-import numpy as np
-from typing import Tuple
+
+TARGET = 85.0  # cible en %
+
+ENERGY_AGENT_GROUPS = {
+    "Mazout": [
+        "agent_energetique_ef_mazout_kg",
+        "agent_energetique_ef_mazout_litres",
+        "agent_energetique_ef_mazout_kwh",
+    ],
+    "Gaz naturel": [
+        "agent_energetique_ef_gaz_naturel_m3",
+        "agent_energetique_ef_gaz_naturel_kwh",
+    ],
+    "Bois bûches dur": ["agent_energetique_ef_bois_buches_dur_stere"],
+    "Bois bûches tendre": [
+        "agent_energetique_ef_bois_buches_tendre_stere",
+        "agent_energetique_ef_bois_buches_tendre_kwh",
+    ],
+    "Pellets": [
+        "agent_energetique_ef_pellets_m3",
+        "agent_energetique_ef_pellets_kg",
+        "agent_energetique_ef_pellets_kwh",
+    ],
+    "Plaquettes": [
+        "agent_energetique_ef_plaquettes_m3",
+        "agent_energetique_ef_plaquettes_kwh",
+    ],
+    "CAD": ["agent_energetique_ef_cad_kwh"],
+    "Électricité PAC": ["agent_energetique_ef_electricite_pac_kwh"],
+    "Électricité directe": ["agent_energetique_ef_electricite_directe_kwh"],
+    "Autre": ["agent_energetique_ef_autre_kwh"],
+}
 
 
 def safe_numeric_conversion(series):
-    """Convert series to numeric, replacing errors with 0"""
     return pd.to_numeric(series, errors="coerce").fillna(0)
 
 
 def filter_energy_data(df: pd.DataFrame) -> pd.DataFrame:
-    """
-    Filter data to include only rows with energy agents > 0
-    Handles type conversion and missing data safely
-
-    Args:
-        df (pd.DataFrame): Input DataFrame containing energy data
-
-    Returns:
-        pd.DataFrame: Filtered DataFrame containing only rows with positive energy values
-    """
-    # List of energy-related columns
-    energy_columns = [
-        "agent_energetique_ef_mazout_litres",
-        "agent_energetique_ef_mazout_kwh",
-        "agent_energetique_ef_gaz_naturel_m3",
-        "agent_energetique_ef_gaz_naturel_kwh",
-        "agent_energetique_ef_bois_buches_dur_stere",
-        "agent_energetique_ef_bois_buches_tendre_stere",
-        "agent_energetique_ef_bois_buches_tendre_kwh",
-        "agent_energetique_ef_pellets_m3",
-        "agent_energetique_ef_pellets_kg",
-        "agent_energetique_ef_pellets_kwh",
-        "agent_energetique_ef_plaquettes_m3",
-        "agent_energetique_ef_plaquettes_kwh",
-        "agent_energetique_ef_cad_kwh",
-        "agent_energetique_ef_electricite_pac_kwh",
-        "agent_energetique_ef_electricite_directe_kwh",
-        "agent_energetique_ef_autre_kwh",
-    ]
-
+    all_energy_cols = [col for cols in ENERGY_AGENT_GROUPS.values() for col in cols]
     try:
-        # Create a copy of the dataframe
         df_clean = df.copy()
-
-        # Convert all energy columns to numeric, replacing errors with 0
-        for col in energy_columns:
+        for col in all_energy_cols:
             if col in df_clean.columns:
                 df_clean[col] = safe_numeric_conversion(df_clean[col])
             else:
                 df_clean[col] = 0
-
-        # Calculate total energy
-        total_energy = sum(df_clean[col] for col in energy_columns)
-
-        # Return filtered dataframe
+        total_energy = sum(df_clean[col] for col in all_energy_cols if col in df_clean.columns)
         return df_clean[total_energy > 0]
-
     except Exception as e:
-        st.error(f"Error in filter_energy_data: {str(e)}")
+        st.error(f"Erreur filter_energy_data: {str(e)}")
         return pd.DataFrame()
+
+
+def _last_per_project(df: pd.DataFrame) -> pd.DataFrame:
+    """One row per project — the most recent date_rapport."""
+    df = df.copy()
+    for col in ["date_rapport", "periode_start", "periode_end"]:
+        if col in df.columns:
+            df[col] = pd.to_datetime(df[col], errors="coerce")
+    df = df.sort_values(["nom_projet", "date_rapport"], na_position="last")
+    idx = df.groupby("nom_projet")["date_rapport"].idxmax()
+    return df.loc[idx]
+
+
+def display_kpi_metrics(df: pd.DataFrame):
+    try:
+        df_energy = filter_energy_data(df)
+        if df_energy.empty:
+            return
+
+        last = _last_per_project(df_energy)
+        obj = pd.to_numeric(last["atteinte_objectif"], errors="coerce").fillna(0) * 100
+
+        total = len(last)
+        above = int((obj >= TARGET).sum())
+        below = total - above
+        avg = obj.mean()
+
+        c1, c2, c3, c4 = st.columns(4)
+        c1.metric("Sites actifs", total)
+        c2.metric(
+            "Objectif atteint ≥ 85%",
+            f"{above}/{total}",
+            delta=f"{above / total * 100:.0f}%" if total else "0%",
+        )
+        c3.metric(
+            "Sous objectif < 85%",
+            f"{below}/{total}",
+            delta=f"-{below}" if below else None,
+            delta_color="inverse",
+        )
+        c4.metric(
+            "Objectif moyen",
+            f"{avg:.1f}%",
+            delta=f"{avg - TARGET:+.1f}% vs cible",
+            delta_color="normal" if avg >= TARGET else "inverse",
+        )
+    except Exception as e:
+        st.error(f"Erreur KPI: {str(e)}")
 
 
 def display_last_calculations(df: pd.DataFrame):
-    """
-    Display the last calculation dates for each project
-
-    Args:
-        df (pd.DataFrame): Input DataFrame containing project data
-    """
     try:
-        # Filter energy data with safe conversion
         df_date = filter_energy_data(df.copy())
-
         if df_date.empty:
-            st.warning("No energy data available to display")
+            st.warning("Aucune donnée énergétique disponible")
             return
 
-        # Convert date columns safely
-        date_columns = ["date_rapport", "periode_start", "periode_end"]
-        for col in date_columns:
+        for col in ["date_rapport", "periode_start", "periode_end"]:
             if col in df_date.columns:
                 df_date[col] = pd.to_datetime(df_date[col], errors="coerce")
-            else:
-                df_date[col] = pd.NaT
 
-        # Sort values safely
-        df_date_sorted = df_date.sort_values(
-            ["nom_projet", "date_rapport"], na_position="last"
+        df_date = df_date.sort_values(["nom_projet", "date_rapport"], na_position="last")
+
+        if "atteinte_objectif" in df_date.columns:
+            df_date["atteinte_objectif"] = (
+                pd.to_numeric(df_date["atteinte_objectif"], errors="coerce").fillna(0) * 100
+            )
+
+        idx = df_date.groupby("nom_projet")["date_rapport"].idxmax()
+        want_cols = ["nom_projet", "amoen_id", "date_rapport", "periode_start", "periode_end", "atteinte_objectif"]
+        want_cols = [c for c in want_cols if c in df_date.columns]
+        df_last = df_date.loc[idx, want_cols].sort_values("atteinte_objectif", ascending=True)
+
+        for col in ["date_rapport", "periode_start", "periode_end"]:
+            if col in df_last.columns:
+                df_last[col] = df_last[col].dt.strftime("%Y-%m-%d")
+
+        df_last = df_last.rename(columns={
+            "nom_projet": "Projet",
+            "amoen_id": "AMOén",
+            "date_rapport": "Dernier rapport",
+            "periode_start": "Début période",
+            "periode_end": "Fin période",
+            "atteinte_objectif": "Objectif (%)",
+        }).reset_index(drop=True)
+
+        def color_objective(val):
+            try:
+                v = float(val)
+                if v >= TARGET:
+                    return "background-color: #d4edda; color: #155724"
+                return "background-color: #f8d7da; color: #721c24"
+            except (ValueError, TypeError):
+                return ""
+
+        styled = (
+            df_last.style
+            .applymap(color_objective, subset=["Objectif (%)"])
+            .format({"Objectif (%)": "{:.1f}%"})
         )
-
-        # Format dates
-        for col in date_columns:
-            df_date_sorted[col] = df_date_sorted[col].dt.strftime("%Y-%m-%d")
-
-        # Safely handle atteinte_objectif formatting
-        if "atteinte_objectif" in df_date_sorted.columns:
-            df_date_sorted["atteinte_objectif"] = pd.to_numeric(
-                df_date_sorted["atteinte_objectif"], errors="coerce"
-            ).fillna(0)
-            df_date_sorted["atteinte_objectif"] = (
-                df_date_sorted["atteinte_objectif"] * 100
-            ).apply(lambda x: f"{x:.2f}%")
-
-        # Get last report for each project
-        idx = df_date_sorted.groupby("nom_projet")["date_rapport"].idxmax()
-        df_date = df_date_sorted.loc[
-            idx,
-            [
-                "nom_projet",
-                "date_rapport",
-                "periode_start",
-                "periode_end",
-                "atteinte_objectif",
-            ],
-        ].sort_values(by=["date_rapport"])
-
-        st.write("Date dernier calcul atteinte objectif par projet")
-        st.dataframe(df_date)
+        st.dataframe(styled, use_container_width=True)
 
     except Exception as e:
-        st.error(f"Error in display_last_calculations: {str(e)}")
-        st.dataframe(pd.DataFrame())
-
-
-def display_filtered_data(df: pd.DataFrame) -> pd.DataFrame:
-    """
-    Display filtered data based on user selections
-
-    Args:
-        df (pd.DataFrame): Input DataFrame containing project data
-
-    Returns:
-        pd.DataFrame: Filtered DataFrame based on user selections
-    """
-    try:
-        # Drop unnecessary columns
-        columns_to_drop = [
-            "_id",
-            "sre_pourcentage_lieux_de_rassemblement",
-            "sre_pourcentage_hopitaux",
-            "sre_pourcentage_industrie",
-            "sre_pourcentage_depots",
-            "sre_pourcentage_installations_sportives",
-            "sre_pourcentage_piscines_couvertes",
-        ]
-
-        df_filtre = df.drop(
-            columns=[col for col in columns_to_drop if col in df.columns]
-        )
-
-        # Filters
-        all_amoen = sorted(df_filtre["amoen_id"].unique())
-        filtre_amoen = st.multiselect("AMOén", all_amoen, default=all_amoen)
-
-        # Get projects for selected AMOén
-        projects_for_selected_amoen = sorted(
-            df_filtre[df_filtre["amoen_id"].isin(filtre_amoen)]["nom_projet"].unique()
-        )
-        filtre_projets = st.multiselect(
-            "Projet", projects_for_selected_amoen, default=projects_for_selected_amoen
-        )
-
-        # Apply filters
-        df_filtre = df_filtre[
-            (df_filtre["nom_projet"].isin(filtre_projets))
-            & (df_filtre["amoen_id"].isin(filtre_amoen))
-        ]
-
-        st.write(df_filtre)
-        return df_filtre
-
-    except Exception as e:
-        st.error(f"Error in display_filtered_data: {str(e)}")
-        return pd.DataFrame()
+        st.error(f"Erreur derniers calculs: {str(e)}")
 
 
 def display_objective_chart(df: pd.DataFrame):
-    """
-    Display an objective achievement chart for filtered projects.
-    This function creates an interactive Altair chart showing the percentage of objective
-    achievement across different projects and time periods. The chart includes:
-    - Grouped bars by project with color-coded periods
-    - Dynamic Y-axis scaling based on data
-    - Percentage labels centered above each bar
-    - A dashed reference line at 85%
-    - Interactive tooltips with project details
-    - Legend at the bottom showing time periods
-        df (pd.DataFrame): Filtered project DataFrame containing at least the following columns:
-            - nom_projet: Project/site name
-            - amoen_id: AMOén identifier
-            - periode_start: Start date of the period (string or date format)
-            - periode_end: End date of the period (string or date format)
-            - atteinte_objectif: Objective achievement as a decimal (e.g., 0.85 for 85%)
-    Returns:
-        None: Displays the chart directly in Streamlit using st.altair_chart()
-    Raises:
-        Displays a warning if no data is available for visualization.
-        Displays an error message if an exception occurs during chart generation.
-    Note:
-        - Values are filtered to only show objectives > 0%
-        - Y-axis automatically scales to accommodate all values (minimum 110%)
-        - Periods with null dates are labeled as "Date non spécifiée"
-        - The chart is responsive and stretches to container width
-    """
     try:
         lf = pl.from_pandas(df)
 
@@ -218,86 +173,96 @@ def display_objective_chart(df: pd.DataFrame):
                     .fill_null(0.0)
                     * 100
                 ).alias("atteinte_objectif"),
-                pl.col("periode_start")
-                    .cast(pl.Utf8)
-                    .str.slice(0, 10)
-                    .alias("periode_start"),
-                pl.col("periode_end")
-                    .cast(pl.Utf8)
-                    .str.slice(0, 10)
-                    .alias("periode_end"),
+                pl.col("periode_start").cast(pl.Utf8).str.slice(0, 10).alias("periode_start"),
+                pl.col("periode_end").cast(pl.Utf8).str.slice(0, 10).alias("periode_end"),
             )
             .filter(pl.col("atteinte_objectif") > 0)
         )
 
         if lf.is_empty():
-            st.warning("No data available for visualization")
+            st.warning("Aucune donnée disponible pour le graphique")
             return
 
         lf = lf.with_columns(
-            # Period label for tooltip
             pl.when(
-                pl.col("periode_start").is_not_null()
-                & pl.col("periode_end").is_not_null()
+                pl.col("periode_start").is_not_null() & pl.col("periode_end").is_not_null()
             )
             .then(pl.col("periode_start") + " – " + pl.col("periode_end"))
             .otherwise(pl.lit("Date non spécifiée"))
             .alias("periode"),
-            # Rank within each project group for xOffset positioning
-            pl.int_range(pl.len()).over("nom_projet").alias("periode_rank")
+            pl.int_range(pl.len()).over("nom_projet").alias("periode_rank"),
+            pl.when(pl.col("atteinte_objectif") >= TARGET)
+            .then(pl.lit("≥ 85% ✓"))
+            .otherwise(pl.lit("< 85% ✗"))
+            .alias("statut"),
         )
 
         df_plot = lf.to_pandas()
-
-        # Dynamic Y upper bound: next 10-step above max + one extra step, min 110
         y_max = max(110, (int(df_plot["atteinte_objectif"].max()) // 10 + 2) * 10)
 
-        # Bars
         bars = (
             alt.Chart(df_plot)
-            .mark_bar()
+            .mark_bar(cornerRadiusTopLeft=3, cornerRadiusTopRight=3)
             .encode(
-                x=alt.X(
-                    "nom_projet:N",
-                    axis=alt.Axis(title="", labelAngle=-40, labelFontSize=11),
-                ),
+                x=alt.X("nom_projet:N", axis=alt.Axis(title="", labelAngle=-40, labelFontSize=11)),
                 y=alt.Y(
                     "atteinte_objectif:Q",
-                    title="Atteinte Objectif [%]",
+                    title="Atteinte objectif [%]",
                     scale=alt.Scale(domain=[0, y_max]),
                     axis=alt.Axis(grid=True, tickCount=6),
                 ),
-                xOffset=alt.XOffset(
-                    "periode_rank:O",
-                    scale=alt.Scale(paddingInner=0.05),
+                xOffset=alt.XOffset("periode_rank:O", scale=alt.Scale(paddingInner=0.05)),
+                color=alt.Color(
+                    "statut:N",
+                    scale=alt.Scale(
+                        domain=["≥ 85% ✓", "< 85% ✗"],
+                        range=["#2ecc71", "#e74c3c"],
+                    ),
+                    legend=alt.Legend(title="", orient="top"),
                 ),
                 tooltip=[
                     alt.Tooltip("nom_projet:N", title="Site"),
                     alt.Tooltip("amoen_id:N", title="AMOén"),
                     alt.Tooltip("periode:N", title="Période"),
-                    alt.Tooltip(
-                        "atteinte_objectif:Q",
-                        title="Atteinte Objectif [%]",
-                        format=".1f",
-                    ),
+                    alt.Tooltip("atteinte_objectif:Q", title="Atteinte objectif [%]", format=".1f"),
                 ],
             )
         )
 
-        # Dashed reference line at 85%
+        labels = (
+            alt.Chart(df_plot)
+            .mark_text(dy=-6, fontSize=9, fontWeight="bold")
+            .encode(
+                x=alt.X("nom_projet:N"),
+                y=alt.Y("atteinte_objectif:Q"),
+                xOffset=alt.XOffset("periode_rank:O"),
+                text=alt.Text("atteinte_objectif:Q", format=".0f"),
+                color=alt.condition(
+                    alt.datum.atteinte_objectif >= TARGET,
+                    alt.value("#27ae60"),
+                    alt.value("#c0392b"),
+                ),
+            )
+        )
+
         ref_line = (
-            alt.Chart(pd.DataFrame({"y": [85]}))
-            .mark_rule(color="red", strokeWidth=1.5, strokeDash=[5, 4])
+            alt.Chart(pd.DataFrame({"y": [TARGET]}))
+            .mark_rule(color="#c0392b", strokeWidth=2, strokeDash=[6, 3])
             .encode(y=alt.Y("y:Q"))
         )
 
+        ref_label = (
+            alt.Chart(pd.DataFrame({"y": [TARGET], "label": ["Cible 85%"]}))
+            .mark_text(align="right", dx=-6, dy=-7, color="#c0392b", fontSize=10, fontWeight="bold")
+            .encode(y=alt.Y("y:Q"), text=alt.Text("label:N"), x=alt.value(700))
+        )
+
         fig = (
-            alt.layer(bars, ref_line)
+            alt.layer(bars, labels, ref_line, ref_label)
             .properties(
-                width=700,
-                height=400,
+                height=420,
                 title=alt.TitleParams(
-                    "Atteinte Objectif par Site",
+                    "Atteinte objectif par site",
                     fontSize=14,
                     fontWeight="bold",
                     anchor="start",
@@ -307,39 +272,138 @@ def display_objective_chart(df: pd.DataFrame):
             .configure_axis(labelFontSize=11)
         )
 
-        st.altair_chart(fig, width="stretch")
+        st.altair_chart(fig, use_container_width=True)
 
     except Exception as e:
-        st.error(f"Error in display_objective_chart: {str(e)}")
+        st.error(f"Erreur graphique objectif: {str(e)}")
+
+
+def display_energy_mix_chart(df: pd.DataFrame):
+    try:
+        df_clean = df.copy()
+        rows = []
+        for agent_name, cols in ENERGY_AGENT_GROUPS.items():
+            present = [c for c in cols if c in df_clean.columns]
+            if not present:
+                continue
+            count = int(
+                df_clean[present]
+                .apply(lambda s: pd.to_numeric(s, errors="coerce").fillna(0))
+                .sum(axis=1)
+                .gt(0)
+                .sum()
+            )
+            if count > 0:
+                rows.append({"Agent": agent_name, "Entrées": count})
+
+        if not rows:
+            st.info("Aucun agent énergétique détecté")
+            return
+
+        df_mix = pd.DataFrame(rows).sort_values("Entrées", ascending=True)
+
+        bars = (
+            alt.Chart(df_mix)
+            .mark_bar(color="#3498db", cornerRadiusTopRight=3, cornerRadiusBottomRight=3)
+            .encode(
+                y=alt.Y("Agent:N", sort=None, axis=alt.Axis(labelFontSize=11), title=""),
+                x=alt.X("Entrées:Q", axis=alt.Axis(tickMinStep=1), title="Nombre d'entrées"),
+                tooltip=["Agent:N", "Entrées:Q"],
+            )
+        )
+
+        labels = (
+            alt.Chart(df_mix)
+            .mark_text(align="left", dx=4, fontSize=11)
+            .encode(
+                y=alt.Y("Agent:N", sort=None),
+                x=alt.X("Entrées:Q"),
+                text=alt.Text("Entrées:Q"),
+            )
+        )
+
+        fig = (
+            alt.layer(bars, labels)
+            .properties(
+                height=max(180, len(df_mix) * 36),
+                title=alt.TitleParams(
+                    "Mix énergétique",
+                    fontSize=14,
+                    fontWeight="bold",
+                    anchor="start",
+                ),
+            )
+            .configure_view(strokeWidth=0)
+        )
+        st.altair_chart(fig, use_container_width=True)
+
+    except Exception as e:
+        st.error(f"Erreur graphique mix énergétique: {str(e)}")
+
+
+def display_filtered_data(df: pd.DataFrame) -> pd.DataFrame:
+    try:
+        columns_to_drop = [
+            "_id",
+            "sre_pourcentage_lieux_de_rassemblement",
+            "sre_pourcentage_hopitaux",
+            "sre_pourcentage_industrie",
+            "sre_pourcentage_depots",
+            "sre_pourcentage_installations_sportives",
+            "sre_pourcentage_piscines_couvertes",
+        ]
+        df_filtre = df.drop(columns=[c for c in columns_to_drop if c in df.columns])
+
+        col1, col2 = st.columns(2)
+        with col1:
+            all_amoen = sorted(df_filtre["amoen_id"].unique())
+            filtre_amoen = st.multiselect("AMOén", all_amoen, default=all_amoen)
+        with col2:
+            projects_for_selected = sorted(
+                df_filtre[df_filtre["amoen_id"].isin(filtre_amoen)]["nom_projet"].unique()
+            )
+            filtre_projets = st.multiselect("Projet", projects_for_selected, default=projects_for_selected)
+
+        df_filtre = df_filtre[
+            df_filtre["nom_projet"].isin(filtre_projets) & df_filtre["amoen_id"].isin(filtre_amoen)
+        ]
+        st.dataframe(df_filtre, use_container_width=True, hide_index=True)
+        return df_filtre
+
+    except Exception as e:
+        st.error(f"Erreur données filtrées: {str(e)}")
+        return pd.DataFrame()
 
 
 def display_admin_dashboard(df: pd.DataFrame):
-    """
-    Display the admin dashboard with key figures and visualizations
-
-    Args:
-        df (pd.DataFrame): Input DataFrame containing the projects data
-    """
     try:
-        # Validate input dataframe
-        if not isinstance(df, pd.DataFrame):
-            raise ValueError("Input must be a pandas DataFrame")
-
-        if df.empty:
-            st.warning("No data available to display")
+        if not isinstance(df, pd.DataFrame) or df.empty:
+            st.warning("Aucune donnée disponible")
             return
 
-        # Chiffres clés section
-        st.subheader("Chiffres-clés")
-        display_last_calculations(df)
+        display_kpi_metrics(df)
+        st.divider()
 
-        # Données section
-        st.subheader("Données")
-        filtered_df = display_filtered_data(df)
+        df_energy = filter_energy_data(df)
 
-        # Visualization
-        if not filtered_df.empty:
-            display_objective_chart(filtered_df)
+        st.subheader("Atteinte objectif par site")
+        if not df_energy.empty:
+            display_objective_chart(df_energy)
+
+        st.divider()
+
+        col_left, col_right = st.columns([3, 2])
+        with col_left:
+            st.subheader("Dernier calcul par projet")
+            display_last_calculations(df)
+        with col_right:
+            st.subheader("Mix énergétique")
+            display_energy_mix_chart(df_energy if not df_energy.empty else df)
+
+        st.divider()
+
+        with st.expander("📋 Données brutes", expanded=False):
+            display_filtered_data(df)
 
     except Exception as e:
-        st.error(f"Error in admin dashboard: {str(e)}")
+        st.error(f"Erreur tableau de bord: {str(e)}")


### PR DESCRIPTION
- Add KPI metrics row: sites actifs, sites ≥ 85%, sites < 85%, objectif moyen — each with a color-coded delta vs the 85% target
- Color-code objective chart bars green (≥ 85%) / red (< 85%); add value labels on top of each bar and a "Cible 85%" label on the reference line
- Add energy mix horizontal bar chart showing which energy agents are used across projects and how many entries each has
- Redesign last-calculations table: sorted worst-first, rows colored green/red by threshold, proper French column labels, amoen_id included
- Move raw data table into a collapsed expander; put AMOén/Projet filters side by side in two columns
- Extract ENERGY_AGENT_GROUPS constant to unify agent column lists across all functions; remove unused numpy and Tuple imports